### PR TITLE
Correctly resolve file paths for uploads

### DIFF
--- a/request.cpp
+++ b/request.cpp
@@ -206,7 +206,8 @@ QJSValue RequestPrototype::attach(const QJSValue &name, const QJSValue &path,
     dispositionHeader += name.toString();
     dispositionHeader += "\";";
 
-    QFile *file = new QFile(path.toString(), m_multipart);
+    QUrl url(path.toString());
+    QFile *file = new QFile(url.toLocalFile(), m_multipart);
 
     if (!file->exists()) {
         qWarning("File does not exist");


### PR DESCRIPTION
The current `attach` implementation does not play nicely with different URLs and only accepts absolute paths without a file scheme. The proposed change allows to use files with the following formats, especially coming from the QML [FileDialog](http://doc.qt.io/qt-5/qml-qtquick-dialogs-filedialog.html#fileUrl-prop) component:

- `file:///home/alex/pictures/pic1.png` (Desktops)
- `file:assets-library://asset/asset.JPG%3Fid=&ext=JPG` (iOS image picker)

It's still possible to use an absolute or relative path with

- `Qt.resolvedUrl("../pic1.png")`

which is the recommended way of resolving local files.

As mentioned, this change allows easy uploading of images from mobile devices.