### PR TITLE
Fix -Wshorten-64-to-32 warning

### DIFF
--- a/request.h
+++ b/request.h
@@ -91,7 +91,7 @@ public:
 
 signals:
     void started();
-    void progress(int loaded, int total);
+    void progress(qint64 loaded, qint64 total);
     void response(QJSValue);
     void end();
 


### PR DESCRIPTION
I fixed a couple of warnings that were popping out because of qint64 to int conversion

    void RequestPrototype::handleUploadProgress(qint64 sent, qint64 total)
    {
        emitEvent(EVENT_PROGRESS, createProgressEvent(true, sent, total));
        emit progress(sent, total); < ---- WARNING
    }

    void RequestPrototype::handleDownloadProgress(qint64 received, qint64 total)
    {
        emitEvent(EVENT_PROGRESS, createProgressEvent(false, received, total));
        emit progress(received, total); < ---- WARNING
    }