### PR TITLE
Make it possible to enable or disable cache saving/loading per request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   - DISPLAY=:99.0
 
 before_install:
-  - sudo add-apt-repository --yes ppa:beineri/opt-qt542
+  - sudo add-apt-repository --yes ppa:beineri/opt-qt542-trusty
   - sudo apt-get update -qq
   - sudo apt-get install -qq qt54base qt54declarative
   - sh -e /etc/init.d/xvfb start

--- a/duperagent.cpp
+++ b/duperagent.cpp
@@ -238,6 +238,12 @@ static void registerTypes()
         "ImageUtils",
         iu_provider);
 
+    qmlRegisterUncreatableType<CacheControl>(
+        DUPERAGENT_URI,
+        1, 0,
+        "CacheControl",
+        "Duperagent CacheControl enums.");
+
     qmlProtectModule(DUPERAGENT_URI, 1);
 }
 

--- a/request.cpp
+++ b/request.cpp
@@ -176,6 +176,19 @@ QJSValue RequestPrototype::redirects(int redirects)
     return self();
 }
 
+QJSValue RequestPrototype::cacheSave(bool enabled)
+{
+    m_request->setAttribute(QNetworkRequest::CacheSaveControlAttribute,
+                            enabled);
+    return self();
+}
+
+QJSValue RequestPrototype::cacheLoad(int value)
+{
+    m_request->setAttribute(QNetworkRequest::CacheLoadControlAttribute,
+                            value);
+    return self();
+}
 
 QJSValue RequestPrototype::query(const QJSValue &query)
 {

--- a/request.h
+++ b/request.h
@@ -19,6 +19,19 @@ class QQmlEngine;
 
 namespace com { namespace cutehacks { namespace duperagent {
 
+class CacheControl : public QObject {
+    Q_OBJECT
+    Q_ENUMS(CacheLoadControl)
+
+public:
+    enum CacheLoadControl {
+        AlwaysNetwork = QNetworkRequest::AlwaysNetwork,
+        PreferNetwork = QNetworkRequest::PreferNetwork,
+        PreferCache = QNetworkRequest::PreferCache,
+        AlwaysCache = QNetworkRequest::AlwaysCache
+    };
+};
+
 typedef QHash<QString, QByteArray> ContentTypeMap;
 class Promise;
 
@@ -63,6 +76,8 @@ public:
     Q_INVOKABLE QJSValue accept(const QJSValue&);
     Q_INVOKABLE QJSValue auth(const QString&, const QString&);
     Q_INVOKABLE QJSValue redirects(int);
+    Q_INVOKABLE QJSValue cacheSave(bool);
+    Q_INVOKABLE QJSValue cacheLoad(int);
     Q_INVOKABLE QJSValue query(const QJSValue&);
     Q_INVOKABLE QJSValue field(const QJSValue&, const QJSValue& = QJSValue());
     Q_INVOKABLE QJSValue attach(const QJSValue&, const QJSValue& = QJSValue(),

--- a/tests/tst_duperagent.qml
+++ b/tests/tst_duperagent.qml
@@ -327,6 +327,106 @@ TestCase {
         async.wait(timeout);
     }
 
+    function test_cache_load_always_cache() {
+        sleep(5000);
+
+        Http.Request
+            .get("http://httpbin.org/cache/3")
+            .cacheSave(true)
+            .end(function(err, res){
+                verify(!err);
+                verify(!res.fromCache);
+                done();
+            });
+
+        async.wait(timeout);
+        async.clear();
+
+        sleep(5000);
+
+        Http.Request
+            .get("http://httpbin.org/cache/3")
+            .cacheLoad(Http.CacheControl.AlwaysCache)
+            .end(function(err, res){
+                verify(res.fromCache);
+                done();
+            });
+
+        async.wait(timeout);
+    }
+
+    function test_cache_load_always_network() {
+        sleep(5000);
+
+        Http.Request
+            .get("http://httpbin.org/cache/3")
+            .cacheSave(true)
+            .end(function(err, res){
+                verify(!res.fromCache);
+                done();
+            });
+
+        async.wait(timeout);
+        async.clear();
+
+        Http.Request
+            .get("http://httpbin.org/cache/3")
+            .cacheLoad(Http.CacheControl.AlwaysNetwork)
+            .end(function(err, res){
+                verify(!res.fromCache);
+                done();
+            });
+
+        async.wait(timeout);
+    }
+
+    function test_cache_save() {
+        sleep(5000);
+
+        Http.Request
+            .get("http://httpbin.org/cache/3")
+            .cacheSave(true)
+            .end(function(err, res){
+                verify(!res.fromCache);
+                done();
+            });
+
+        async.wait(timeout);
+        async.clear();
+
+        Http.Request
+            .get("http://httpbin.org/cache/3")
+            .end(function(err, res){
+                verify(res.fromCache);
+                done();
+            });
+
+        async.wait(timeout);
+        async.clear();
+
+        sleep(5000);
+
+        Http.Request
+            .get("http://httpbin.org/cache/3")
+            .cacheSave(false)
+            .end(function(err, res){
+                verify(!res.fromCache);
+                done();
+            });
+
+        async.wait(timeout);
+        async.clear();
+
+        Http.Request
+            .get("http://httpbin.org/cache/3")
+            .end(function(err, res){
+                verify(!res.fromCache);
+                done();
+            });
+
+        async.wait(timeout);
+    }
+
     function test_multipart() {
         Http.Request
             .post("http://httpbin.org/post")


### PR DESCRIPTION
Hello.

I have implemented the API as discussed in issue #15.
`cacheSave()` seems to be working fine.
Unfortunately `cacheLoad()` blocks the request for some reason.
Do you see anything obviously wrong with what I am doing?
I do not have much experience with Qt so any help would be greatly appreciated.