### PR TITLE
Add response property to error objects

### DIFF
--- a/request.cpp
+++ b/request.cpp
@@ -625,6 +625,11 @@ void RequestPrototype::handleFinished()
     QJSValueList args;
 
     ResponsePrototype *rep = new ResponsePrototype(m_engine, m_reply);
+
+    if (m_error.isError()) {
+        m_error.setProperty("response", m_engine->newQObject(rep));
+    }
+
     QJSValue res = m_engine->newQObject(rep);
     args << m_error << m_engine->newQObject(rep);
 


### PR DESCRIPTION
This pull request adds a `response` property to error objects. This is modeled after SuperAgent, which describes this property in their [section on error handling](http://visionmedia.github.io/superagent/#error-handling) (emphasis mine):
> Note that superagent considers 4xx and 5xx responses (as well as unhandled 3xx responses) errors by default. For example, if you get a `304 Not modified`, `403 Forbidden` or `500 Internal server error` response, this status information will be available via `err.status`. **Errors from such responses also contain an `err.response` field with all of the properties mentioned in "Response properties".**