### PR TITLE
fix Qt 5.15.2 and beyond warning on Singleton's that start in lowercase

### DIFF
--- a/duperagent.cpp
+++ b/duperagent.cpp
@@ -202,23 +202,11 @@ static QObject *iu_provider(QQmlEngine *engine, QJSEngine *)
 
 static void registerTypes()
 {
-//     qmlRegisterSingletonType<Request>(
-//         DUPERAGENT_URI,
-//         1, 0,
-//         "request",
-//         request_provider);
-
     qmlRegisterSingletonType<Request>(
         DUPERAGENT_URI,
         1, 0,
         "Request",
         request_provider);
-
-//     qmlRegisterSingletonType<PromiseModule>(
-//         DUPERAGENT_URI,
-//         1, 0,
-//         "promise",
-//         promise_provider);
 
     qmlRegisterSingletonType<PromiseModule>(
         DUPERAGENT_URI,

--- a/duperagent.cpp
+++ b/duperagent.cpp
@@ -202,11 +202,11 @@ static QObject *iu_provider(QQmlEngine *engine, QJSEngine *)
 
 static void registerTypes()
 {
-    qmlRegisterSingletonType<Request>(
-        DUPERAGENT_URI,
-        1, 0,
-        "request",
-        request_provider);
+//     qmlRegisterSingletonType<Request>(
+//         DUPERAGENT_URI,
+//         1, 0,
+//         "request",
+//         request_provider);
 
     qmlRegisterSingletonType<Request>(
         DUPERAGENT_URI,
@@ -214,11 +214,11 @@ static void registerTypes()
         "Request",
         request_provider);
 
-    qmlRegisterSingletonType<PromiseModule>(
-        DUPERAGENT_URI,
-        1, 0,
-        "promise",
-        promise_provider);
+//     qmlRegisterSingletonType<PromiseModule>(
+//         DUPERAGENT_URI,
+//         1, 0,
+//         "promise",
+//         promise_provider);
 
     qmlRegisterSingletonType<PromiseModule>(
         DUPERAGENT_URI,


### PR DESCRIPTION
Lowercase Qml Singletons are deprecated in newer Qt. This removes the warning by commenting the lowercase counterpart of the Promise and Request singletons