### PR TITLE
BasicAuth must be base64 encoding not base64url (rfc4648)

### DIFF
--- a/request.cpp
+++ b/request.cpp
@@ -166,7 +166,7 @@ QJSValue RequestPrototype::auth(const QString &user, const QString &password)
     QByteArray value = QByteArray("Basic ").append(
                 (user + ":" + password)
                 .toUtf8()
-                .toBase64(QByteArray::Base64UrlEncoding));
+                .toBase64());
 
     m_request->setRawHeader(AUTH_HEADER, value);
     return self();


### PR DESCRIPTION
see: https://datatracker.ietf.org/doc/html/rfc4648#section-4

We don't set any option and use the default (QByteArray::Base64Encoding).